### PR TITLE
Updated build tools & A force close bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Fri Aug 19 17:55:34 IDT 2016
+#Fri Aug 19 18:31:53 IDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 07 17:26:44 CEST 2016
+#Fri Aug 19 17:55:34 IDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/library/src/main/java/com/heinrichreimersoftware/androidissuereporter/IssueReporterActivity.java
+++ b/library/src/main/java/com/heinrichreimersoftware/androidissuereporter/IssueReporterActivity.java
@@ -19,6 +19,7 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
@@ -53,41 +54,27 @@ public abstract class IssueReporterActivity extends AppCompatActivity {
 
     private static final int STATUS_BAD_CREDENTIALS = 401;
     private static final int STATUS_ISSUES_NOT_ENABLED = 410;
-
-    @StringDef({RESULT_OK, RESULT_BAD_CREDENTIALS, RESULT_INVALID_TOKEN, RESULT_ISSUES_NOT_ENABLED,
-            RESULT_UNKNOWN})
-    @Retention(RetentionPolicy.SOURCE)
-    private @interface Result {
-    }
-
     private static final String RESULT_OK = "RESULT_OK";
     private static final String RESULT_BAD_CREDENTIALS = "RESULT_BAD_CREDENTIALS";
     private static final String RESULT_INVALID_TOKEN = "RESULT_INVALID_TOKEN";
     private static final String RESULT_ISSUES_NOT_ENABLED = "RESULT_ISSUES_NOT_ENABLED";
     private static final String RESULT_UNKNOWN = "RESULT_UNKNOWN";
-
     private boolean emailRequired;
-
     private int bodyMinChar;
-
     private Toolbar toolbar;
-
     private TextInputEditText inputTitle;
     private TextInputEditText inputDescription;
     private TextView textDeviceInfo;
     private ImageButton buttonDeviceInfo;
     private ExpandableRelativeLayout layoutDeviceInfo;
     private ExpandableRelativeLayout layoutAnonymous;
-
     private TextInputEditText inputUsername;
     private TextInputEditText inputPassword;
     private TextInputEditText inputEmail;
     private RadioButton optionUseAccount;
     private RadioButton optionAnonymous;
     private ExpandableRelativeLayout layoutLogin;
-
     private FloatingActionButton buttonSend;
-
     private String token;
 
     @Override
@@ -272,18 +259,39 @@ public abstract class IssueReporterActivity extends AppCompatActivity {
     }
 
     private void setError(TextInputEditText editText, @StringRes int errorRes) {
-        TextInputLayout layout = (TextInputLayout) editText.getParent();
-        layout.setError(getString(errorRes));
+        try {
+            View layout = (View) editText.getParent();
+            while (!layout.getClass().getSimpleName().equals(TextInputLayout.class.getSimpleName()))
+                layout = (View) layout.getParent();
+            TextInputLayout realLayout = (TextInputLayout) layout;
+            realLayout.setError(getString(errorRes));
+        } catch (ClassCastException | NullPointerException e) {
+            Log.e(e.getMessage(), "In setError(TextInputEditText, int)");
+        }
     }
 
     private void setError(TextInputEditText editText, String error) {
-        TextInputLayout layout = (TextInputLayout) editText.getParent();
-        layout.setError(error);
+        try {
+            View layout = (View) editText.getParent();
+            while (!layout.getClass().getSimpleName().equals(TextInputLayout.class.getSimpleName()))
+                layout = (View) layout.getParent();
+            TextInputLayout realLayout = (TextInputLayout) layout;
+            realLayout.setError(error);
+        } catch (ClassCastException | NullPointerException e) {
+            Log.e(e.getMessage(), "In setError(TextInputEditText, String)");
+        }
     }
 
     private void removeError(TextInputEditText editText) {
-        TextInputLayout layout = (TextInputLayout) editText.getParent();
-        layout.setError(null);
+        try {
+            View layout = (View) editText.getParent();
+            while (!layout.getClass().getSimpleName().equals(TextInputLayout.class.getSimpleName()))
+                layout = (View) layout.getParent();
+            TextInputLayout realLayout = (TextInputLayout) layout;
+            realLayout.setError(null);
+        } catch (ClassCastException | NullPointerException e) {
+            Log.e(e.getMessage(), "In removeError(TextInputEditText)");
+        }
     }
 
     private void sendBugReport(GithubLogin login, String email) {
@@ -307,7 +315,7 @@ public abstract class IssueReporterActivity extends AppCompatActivity {
         this.emailRequired = required;
         if (required) {
             optionAnonymous.setText(R.string.air_label_use_email);
-            ((TextInputLayout) inputEmail.getParent()).setHint(getString(R.string.air_label_email));
+            ((TextInputLayout) findViewById(R.id.air_inputEmailParent)).setHint(getString(R.string.air_label_email));
         } else {
             optionAnonymous.setText(R.string.air_label_use_guest);
             ((TextInputLayout) inputEmail.getParent()).setHint(getString(R.string.air_label_email_optional));
@@ -327,15 +335,16 @@ public abstract class IssueReporterActivity extends AppCompatActivity {
         return null;
     }
 
+    @StringDef({RESULT_OK, RESULT_BAD_CREDENTIALS, RESULT_INVALID_TOKEN, RESULT_ISSUES_NOT_ENABLED,
+            RESULT_UNKNOWN})
+    @Retention(RetentionPolicy.SOURCE)
+    private @interface Result {
+    }
+
     private static class ReportIssueTask extends DialogAsyncTask<Void, Void, String> {
         private final Report report;
         private final GithubTarget target;
         private final GithubLogin login;
-
-        public static void report(Activity activity, Report report, GithubTarget target,
-                                  GithubLogin login) {
-            new ReportIssueTask(activity, report, target, login).execute();
-        }
 
         private ReportIssueTask(Activity activity, Report report, GithubTarget target,
                                 GithubLogin login) {
@@ -343,6 +352,11 @@ public abstract class IssueReporterActivity extends AppCompatActivity {
             this.report = report;
             this.target = target;
             this.login = login;
+        }
+
+        public static void report(Activity activity, Report report, GithubTarget target,
+                                  GithubLogin login) {
+            new ReportIssueTask(activity, report, target, login).execute();
         }
 
         @Override

--- a/library/src/main/java/com/heinrichreimersoftware/androidissuereporter/IssueReporterActivity.java
+++ b/library/src/main/java/com/heinrichreimersoftware/androidissuereporter/IssueReporterActivity.java
@@ -54,6 +54,11 @@ public abstract class IssueReporterActivity extends AppCompatActivity {
 
     private static final int STATUS_BAD_CREDENTIALS = 401;
     private static final int STATUS_ISSUES_NOT_ENABLED = 410;
+    @StringDef({RESULT_OK, RESULT_BAD_CREDENTIALS, RESULT_INVALID_TOKEN, RESULT_ISSUES_NOT_ENABLED,
+            RESULT_UNKNOWN})
+    @Retention(RetentionPolicy.SOURCE)
+    private @interface Result {
+    }
     private static final String RESULT_OK = "RESULT_OK";
     private static final String RESULT_BAD_CREDENTIALS = "RESULT_BAD_CREDENTIALS";
     private static final String RESULT_INVALID_TOKEN = "RESULT_INVALID_TOKEN";
@@ -333,12 +338,6 @@ public abstract class IssueReporterActivity extends AppCompatActivity {
 
     protected String getGuestToken() {
         return null;
-    }
-
-    @StringDef({RESULT_OK, RESULT_BAD_CREDENTIALS, RESULT_INVALID_TOKEN, RESULT_ISSUES_NOT_ENABLED,
-            RESULT_UNKNOWN})
-    @Retention(RetentionPolicy.SOURCE)
-    private @interface Result {
     }
 
     private static class ReportIssueTask extends DialogAsyncTask<Void, Void, String> {

--- a/library/src/main/res/layout/air_card_login.xml
+++ b/library/src/main/res/layout/air_card_login.xml
@@ -109,6 +109,7 @@
                     <android.support.design.widget.TextInputLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:id="@+id/air_inputEmailParent"
                         android:layout_marginTop="@dimen/air_baseline_half">
 
                         <android.support.design.widget.TextInputEditText


### PR DESCRIPTION
Edit: This PR solves #44

I'm not sure what was the source of the bug but after updating the build tools of my app the ReporterActivity kept force closing on create (When using the setGuestEmailRequired(true)) and when clicking the submit button.
This is the exception I was getting
   ```
      java.lang.ClassCastException: android.widget.FrameLayout cannot be cast to android.support.design.widget.TextInputLayout
              at com.heinrichreimersoftware.androidissuereporter.IssueReporterActivity.validateInput(Unknown)
              at com.heinrichreimersoftware.androidissuereporter.IssueReporterActivity.reportIssue(Unknown)
              at com.heinrichreimersoftware.androidissuereporter.IssueReporterActivity.access$100(Unknown)
              at com.heinrichreimersoftware.androidissuereporter.IssueReporterActivity$5.onClick(Unknown)
```

I managed to fix it by replacing the view.getParent with view.getParent().getParent().
But just to be safe (and for backwards compatibility) I added a while loop to check if the correct class is being cast (until the correct class is being cast)
```

View layout = (View) editText.getParent();
while (!layout.getClass().getSimpleName().equals(TextInputLayout.class.getSimpleName()))
      layout = (View) layout.getParent();
TextInputLayout realLayout = (TextInputLayout) layout;
```